### PR TITLE
Fix minor issue in MockHttpServletRequest

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,8 @@ public class MockHttpServletResponse implements HttpServletResponse {
 	
 	private static final String CONTENT_LENGTH_HEADER = "Content-Length";
 
+	private static final String LOCATION_HEADER = "Location";
+
 	//---------------------------------------------------------------------
 	// ServletResponse properties
 	//---------------------------------------------------------------------
@@ -94,8 +96,6 @@ public class MockHttpServletResponse implements HttpServletResponse {
 	private int status = HttpServletResponse.SC_OK;
 
 	private String errorMessage;
-
-	private String redirectedUrl;
 
 	private String forwardedUrl;
 
@@ -411,12 +411,13 @@ public class MockHttpServletResponse implements HttpServletResponse {
 			throw new IllegalStateException("Cannot send redirect - response is already committed");
 		}
 		Assert.notNull(url, "Redirect URL must not be null");
-		this.redirectedUrl = url;
+		setHeader(LOCATION_HEADER, url);
+		setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY);
 		setCommitted(true);
 	}
 
 	public String getRedirectedUrl() {
-		return this.redirectedUrl;
+		return getHeader(LOCATION_HEADER);
 	}
 
 	public void setDateHeader(String name, long value) {

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletResponseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springframework.mock.web;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Set;
+
+import javax.servlet.http.HttpServletResponse;
 
 import junit.framework.TestCase;
 
@@ -195,4 +197,20 @@ public class MockHttpServletResponseTests extends TestCase {
 		assertEquals("XY", response.getContentAsString());
 	}
 
+	public void testSendRedirect() throws IOException {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		String redirectUrl = "/redirect";
+		response.sendRedirect(redirectUrl);
+		assertEquals(HttpServletResponse.SC_MOVED_TEMPORARILY, response.getStatus());
+		assertEquals(redirectUrl, response.getHeader("Location"));
+		assertEquals(redirectUrl, response.getRedirectedUrl());
+		assertEquals(true, response.isCommitted());
+	}
+
+	public void testLocationHeaderUpdatesGetRedirectedUrl() {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		String redirectUrl = "/redirect";
+		response.setHeader("Location", redirectUrl);
+		assertEquals(redirectUrl, response.getRedirectedUrl());
+	}
 }


### PR DESCRIPTION
# A few points of discussion:
- This changes the behavior of getRedirectedUrl since if someone adds the Location header it is now updated. I think this is correct behavior but it could be preferable to do this in another JIRA. I did it in this one because I thought it was weird keeping the state in two distinct locations. Please let me know if you would like this changed.
- [SPR-9594](https://jira.springsource.org/browse/SPR-9594) points out the spec states "Sends a temporary redirect response ..." Interestingly enough there is a constant named [SC_TEMPORARY_REDIRECT](http://docs.oracle.com/cd/E17802_01/products/products/servlet/2.3/javadoc/javax/servlet/http/HttpServletResponse.html#SC_TEMPORARY_REDIRECT) that is equal to 307 (not 302 as we believe the status should be). I still think 302 is the correct status, but thought I would point this out. There are two constants for a 302 ([SC_MOVED_TEMPORARILY](http://docs.oracle.com/cd/E17802_01/products/products/servlet/2.3/javadoc/javax/servlet/http/HttpServletResponse.html#SC_MOVED_TEMPORARILY) and [SC_FOUND](http://tomcat.apache.org/tomcat-5.5-doc/servletapi/javax/servlet/http/HttpServletResponse.html#SC_FOUND)) that have documentation stating it should be used for temporarily moved. The reason I brought up SC_TEMPORARY_REDIRECT is that it is an exact match of the spec.
# Changes

Previously MockHttpServletRequest#sendRedirect did not set the HTTP status
or the Location header. This does not conform to the HttpServletRequest
interface.

MockHttpServletRequest will now:
- Set the HTTP status to 302 on sendRedirect
- Set the Location header on sendRedirect
- Ensure the Location header and getRedirectedUrl are kept in synch

Issue: SPR-9594
